### PR TITLE
[enh] Changed the og properties to suit the new domain name

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -15,8 +15,8 @@
     {% endcompress %}
 <meta property="og:title" content="DocHub" />
 <meta property="og:type" content="website" />
-<meta property="og:image" content="http://cours.urlab.be/static/images/facebook_cover.png" />
-<meta property="og:url" content="http://cours.urlab.be" />
+<meta property="og:image" content="http://dochub.be/static/images/facebook_cover.png" />
+<meta property="og:url" content="http://dochub.be" />
 <meta property="og:description" content="DocHub vous permet de poser des questions aux autres étudiants, échanger vos notes, vos résumés, d'anciens examens et bien plus encore. " />
     <link rel="icon" type="image/png" href="/static/images/favicon.png" />
     {% compress js %}

--- a/templates/p402.html
+++ b/templates/p402.html
@@ -15,8 +15,8 @@
     {% endcompress %}
 <meta property="og:title" content="DocHub" />
 <meta property="og:type" content="website" />
-<meta property="og:image" content="http://cours.urlab.be/static/images/facebook_cover.png" />
-<meta property="og:url" content="http://cours.urlab.be" />
+<meta property="og:image" content="http://dochub.be/static/images/facebook_cover.png" />
+<meta property="og:url" content="http://dochub.be" />
 <meta property="og:description" content="DocHub vous permet de poser des questions aux autres étudiants, échanger vos notes, vos résumés, d'anciens examens et bien plus encore. " />
     <link rel="icon" type="image/png" href="/static/images/favicon.png" />
     {% compress js %}


### PR DESCRIPTION
Dans les og::image et og::url, l'ancien nom de domaine "cours.urlab.be" était encore utilisé.