### PR TITLE
Tags en couleur cliquables

### DIFF
--- a/polydag/models.py
+++ b/polydag/models.py
@@ -14,6 +14,7 @@ from __future__ import unicode_literals
 
 from django.db import models
 from polymorphic import PolymorphicModel
+from math import sin, pi
 import re
 
 
@@ -157,6 +158,11 @@ class Keyword(models.Model):
     in the site's graph, but semantically close.
     """
     name = models.CharField(max_length=50, unique=True)
+
+    @property
+    def color(self):
+        return "#%02x%02x%02x" % tuple(
+            abs(int(200 * sin(self.id + x*pi/3))) for x in range(3))
 
     def __unicode__(self):
         return self.name

--- a/static/style/main.css
+++ b/static/style/main.css
@@ -285,3 +285,11 @@ i.round-icon.medium{
 .back-icon:hover {
     color: #666;
 }
+
+.tag-item:hover {
+    color: white;
+}
+
+.tag-item.active {
+    font-weight: bold;
+}

--- a/templates/course.html
+++ b/templates/course.html
@@ -61,7 +61,7 @@
     </div>
   </div>
   <div class="large-12 medium-12 columns">
-    {% for node in children_nodes %}{% with node.keywords.all as tags%}
+    {% for node in children_nodes %}{% with node.keywords.all as tags %}
       {% ifchanged node.year %}
         <h3>{% if node.year != "Archives" %}Année académique {% endif %}{{ node.year }}</h3>
       {% endifchanged %}
@@ -115,9 +115,11 @@
           {% endif %}
           {% if tags %}<i class="fi-pricetag-multiple"></i> {% endif %}
           {% for kw in tags%}
-            <span class="radius label {% if node.classBasename == 'Thread' %}secondary{% endif %}">
+            <a data-id="{{kw.id}}" href="#"
+               style="background-color: {{kw.color}}; border: solid 2px {{kw.color}};"
+               class="radius label tag-item {% if node.classBasename == 'Thread' %}secondary{% endif %}">
               {{kw}}
-            </span>
+            </a>
           {% endfor %}
         </div>
         </div>
@@ -167,6 +169,24 @@
   {% compress js %}
     <script src="/static/3party/select/select2.js"></script>
     <script src="/static/3party/select/select2_locale_fr.js"></script>
+    <script type="">
+      var toggleTag = function(){
+        var bkg = $(this).css('background-color');
+        $(this).css("background-color", $(this).css("color"));
+        $(this).css("color", bkg);
+        $(this).toggleClass("active");
+      }
+
+      var toggleSameTags = function(ev){
+        var clicked = $(ev.delegateTarget);
+        var tag_id = clicked.attr("data-id");
+        console.log("Toggle " + tag_id);
+        $(".tag-item[data-id=" + tag_id + "]").each(toggleTag);
+        return false;
+      }
+
+      $(document).ready(function(){$('.tag-item').click(toggleSameTags);});
+    </script>
   {% endcompress %}
   {% compress js %}
   <script>


### PR DESCRIPTION
Fonctionnalité depuis un bout de temps dans add-comments_to_docs. Le code relatif aux commentaires sur les documents est obsolète et à peine commencé, autant le recommencer proprement, et intégrer le diff des couleurs pour les tags.