### PR TITLE
[add] Preferred zoom level for document viewer as cookie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,5 +64,8 @@ static/3party/select:
 	@mkdir static/3party/select && true
 	mv ${SELECTFILES} static/3party/select
 
+static/3party/js/js.cookie.js:
+	curl https://raw.githubusercontent.com/js-cookie/js-cookie/master/src/js.cookie.js > $@
+
 shower-clean:
 	rm -rf static/3party/

--- a/static/scripts/viewer.js
+++ b/static/scripts/viewer.js
@@ -13,6 +13,8 @@ Number.prototype.pad = function(l) {
     return padding + n;
 }
 
+const COOKIE_NAME = "viewer-preferred-zoom";
+
 var viewer = function(doc) {
     var current_page = 0;
     var current_thumb = 0;
@@ -118,8 +120,9 @@ var viewer = function(doc) {
 
     var zoom_draw = function(z) {
         console.log(z);
-        if (z != zoom) {
+        if (z && z != zoom) {
             zoom = z;
+            Cookies.set(COOKIE_NAME, zoom);
             $('#zoom').val(zoom + '%');
 
             if (zoom >= 125 && mode == 600)
@@ -178,6 +181,7 @@ var viewer = function(doc) {
         load_pages();
         load_thumbs();
         show_thumb_page(0);
+        zoom_draw(parseFloat(Cookies.get(COOKIE_NAME)));
     });
 
     return {

--- a/templates/documents/viewer.html
+++ b/templates/documents/viewer.html
@@ -6,6 +6,7 @@
 {% endblock %}
 
 {% block script %}
+<script src="/static/3party/js/js.cookie.js" type="text/javascript"></script>
 <script src="/static/scripts/viewer.js"></script>
 
 {% cache 1 viewer.js object.id %}


### PR DESCRIPTION
On enregistre le niveau de zoom préférré de l'utilisateur en cookie pour le viewer de documents (évite de rezoomer à chaque fois pour atteindre le zoom idéal de chacun)